### PR TITLE
Fix activeness to accommodate v3.5 logic

### DIFF
--- a/app/models/workarea/catalog/product.decorator
+++ b/app/models/workarea/catalog/product.decorator
@@ -27,14 +27,8 @@ module Workarea
       template == 'family'
     end
 
-    def active?
-      attribute = if Workarea.config.localized_active_fields
-                    read_attribute(:active)[I18n.locale.to_s]
-                  else
-                    read_attribute(:active)
-                  end
-
-      attribute && (variants.active.any? || product_ids.present?)
+    def active_by_relations?
+      super || self.class.in(id: product_ids).any?(&:active?)
     end
 
     def purchasable?

--- a/lib/workarea/package_products/version.rb
+++ b/lib/workarea/package_products/version.rb
@@ -1,5 +1,5 @@
 module Workarea
   module PackageProducts
-    VERSION = '3.3.1'.freeze
+    VERSION = '3.4.0.pre'.freeze
   end
 end

--- a/test/models/workarea/catalog/package_product_test.rb
+++ b/test/models/workarea/catalog/package_product_test.rb
@@ -53,15 +53,22 @@ module Workarea
 
       def test_active?
         @product_one.active = true
-        @product_one.variants.clear
+        assert(@product_one.active?)
 
+        @product_one.variants.clear
         refute(@product_one.active?)
 
-        @product_one.active = true
-        @product_one.product_ids = [1, 2]
-        @product_one.variants.clear
+        packaged_one = create_product(active: true)
+        packaged_two = create_product(active: false)
 
+        @product_one.product_ids = [packaged_one.id]
         assert(@product_one.active?)
+
+        @product_one.product_ids = [packaged_one.id, packaged_two.id]
+        assert(@product_one.active?)
+
+        @product_one.product_ids = [packaged_two.id]
+        refute(@product_one.active?)
       end
     end
   end


### PR DESCRIPTION
This also only allows a package to be active if at least one of it's
children products are active.

Fix for https://github.com/workarea-commerce/mega-build/runs/271831151#step:4:1452

Will pass build once https://github.com/workarea-commerce/workarea/pull/187 is merged.